### PR TITLE
Now we can say Nintendo :godmode: :tada:

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -84,8 +84,8 @@
         "icon":"block.svg",
         "alt": "This incident is about something getting blocked or restricted",
         "date":"2020-12-05",
-        "name":"The Splat 2 stream was canceled",
-        "description": "The NA stream for Splat 2 was cancelled when the company realized teams used #FreeMelee on their names in support for the SSBM community."
+        "name":"The Splatoon 2 tournament stream was canceled",
+        "description": "The NA stream for Splatoon 2 was cancelled when the company realized teams used #FreeMelee on their names in support for the SSBM community."
     },
     {
         "url": "https://dotesports.com/streaming/news/multiple-streamers-banned-by-nintendo-for-playing-hyrule-warriors-age-of-calamity",

--- a/data/data.json
+++ b/data/data.json
@@ -2,7 +2,7 @@
     {
         "url": "https://www.eurogamer.net/articles/2021-11-02-switch-hacker-gary-bowser-pleads-guilty",
         "icon":"balance.svg",
-        "alt": "This incident was about someone having to pay compensation or any monetary problems caused by the big N",
+        "alt": "This incident was about someone having to pay compensation or any monetary problems caused by Nintendo",
         "date":"2021-11-02",
         "name":"Gary Bowser pleads guilty",
         "description": "The Canadian Hacker was found guilty and now has to pay $4.5 million, and could also face up to 10 years in jail."
@@ -13,7 +13,7 @@
         "alt":"This incident is about something getting blocked or restricted",
         "date":"2021-09-14",
         "name":"Low Tide City cancels Tournaments for SSB mods",
-        "description":"LTC was organizing Tournaments for Project+, Beyond Melee and 64 Remix, but the big N contacted the organizers and the tournaments were cancelled"
+        "description":"LTC was organizing Tournaments for Project+, Beyond Melee and 64 Remix, but Nintendo contacted the organizers and the tournaments were cancelled"
     },
     {
         "url": "https://kotaku.com/nintendo-back-on-its-bullshit-shuts-down-another-smash-1847585646",
@@ -37,15 +37,15 @@
         "alt": "This incident is about something getting blocked or restricted",
         "date":"2021-08-14",
         "name":"RomUniverse owner is ordered to destroy it's pirated games",
-        "description": "The owner of the defunct site was ordered to destroy all of the big N pirated games they had. This was done anfter the owner hinted he might try to re-stablish the site again."
+        "description": "The owner of the defunct site was ordered to destroy all of Nintendo pirated games they had. This was done anfter the owner hinted he might try to re-stablish the site again."
     },
     {
         "url": "https://www.gamesindustry.biz/articles/2021-06-01-nintendo-to-get-usd2-1m-in-damages-in-lawsuit-against-romuniverse",
         "icon":"balance.svg",
-        "alt": "This incident was about someone having to pay compensation or any monetary problems caused by the big N",
+        "alt": "This incident was about someone having to pay compensation or any monetary problems caused by Nintendo",
         "date":"2021-06-01",
         "name":"RomUniverse loses the lawsuit and has to pay millions",
-        "description":"The ROM site, RomUniverse loses the lawsuit filed by the big N and now it's forced to pay $2.1 millions in damages to the company."
+        "description":"The ROM site, RomUniverse loses the lawsuit filed by Nintendo and now it's forced to pay $2.1 millions in damages to the company."
     },
     {
         "url": "https://www.eurogamer.net/articles/2021-04-17-nintendo-suing-switch-hacker-gary-bowser",
@@ -53,7 +53,7 @@
         "alt": "This incident was about something getting sued or a legal letter was sent",
         "date":"2021-04-17",
         "name":"Gary Bowser is sued",
-        "description": "A 51 year old Canadian and console hacker is sued by the company. According the the big N he was a member of the hack group, Team Xecuter."
+        "description": "A 51 year old Canadian and console hacker is sued by the company. According the Nintendo he was a member of the hack group, Team Xecuter."
     },
     {
         "url": "https://www.polygon.com/22381771/nintendo-dmca-bowser-penis-copyright-patreon-sfm",
@@ -76,8 +76,8 @@
         "icon":"block.svg",
         "alt": "This incident is about something getting blocked or restricted",
         "date":"2020-12-07",
-        "name":"The big N shuts down \"Etikon\" controller memorial",
-        "description": "A legal threat from the big N has shut down the manufacturing and sale of custom-designed Joy-Con controllers honoring Desmond “Etika” Amofah."
+        "name":"Nintendo shuts down \"Etikon\" controller memorial",
+        "description": "A legal threat from Nintendo has shut down the manufacturing and sale of custom-designed Joy-Con controllers honoring Desmond “Etika” Amofah."
     },
     {
         "url": "https://dotesports.com/fgc/news/nintendo-cancels-splatoon-2-na-open-stream-after-teams-use-freemelee-names-in-support-of-super-smash-bros-melee-community",
@@ -92,7 +92,7 @@
         "icon":"block.svg",
         "alt": "This incident is about something getting blocked or restricted",
         "date":"2020-11-20",
-        "name": "Multiple streamers banned by the big N for playing HW:AC",
+        "name": "Multiple streamers banned for playing Hyrule Warriors: AC",
         "description": "Multiple streamers where banned on twitch for playing the game early, even when the game came out in certain countries 12 hours before and even if the creator was streaming in countries where the game was already out."
     },
     {
@@ -101,7 +101,7 @@
         "alt": "This incident is about something getting blocked or restricted",
         "date":"2020-11-09",
         "name":"The Big House 2020",
-        "description": "Because of the pandemic \"The Big House\" 2020 event had to take place online and this forced organizers to use a software called Slippi to play the game online using emulators, but the big N forced organizers to cancel the event."
+        "description": "Because of the pandemic \"The Big House\" 2020 event had to take place online and this forced organizers to use a software called Slippi to play the game online using emulators, but Nintendo forced organizers to cancel the event."
     },
     {
         "url": "https://torrentfreak.com/nintendos-lawyers-nuke-the-missing-link-fangame-with-copyright-complaint-201013/",
@@ -109,15 +109,15 @@
         "alt": "This incident was about something getting sued or a legal letter was sent",
         "date":"2020-10-13",
         "name":"TLoZ the missing Link takedown",
-        "description": "A game made with the engine of OoT wa created by fans and after a few months the big N issued a copyright takedown of the game."
+        "description": "A game made with the engine of OoT wa created by fans and after a few months Nintendo issued a copyright takedown of the game."
     },
     {
         "url": "https://www.videogameschronicle.com/news/nintendo-wins-2-million-in-damages-from-switch-hacking-device-seller/",
         "icon":"balance.svg",
-        "alt": "This incident was about someone having to pay compensation or any monetary problems caused by the big N",
+        "alt": "This incident was about someone having to pay compensation or any monetary problems caused by Nintendo",
         "date":"2020-10-01",
         "name":"Resellers of hacking device have to pay millions",
-        "description": "The big N filed a lawsuit against companies reselling hacking devices for the switch and won the case. The resellers had to pay $2 million in damages after they lost the lawsuit."
+        "description": "Nintendo filed a lawsuit against companies reselling hacking devices for the switch and won the case. The resellers had to pay $2 million in damages after they lost the lawsuit."
     },
     {
         "url": "https://www.polygon.com/2020/9/21/21449786/nintendo-dmca-porn-sex-hentai-princess-peach-untold-tale",
@@ -125,30 +125,30 @@
         "alt": "This incident was about something getting sued or a legal letter was sent",
         "date":"2020-09-21",
         "name":"A sex game received a takedown",
-        "description": "A fan porn made game of a big N character received a DMCA Takedown on Github. The company said that the game didn't fall under fair use and Github took down the repository and website."
+        "description": "A fan porn made game of a Nintendo character received a DMCA Takedown on Github. The company said that the game didn't fall under fair use and Github took down the repository and website."
     },
     {
         "url": "https://www.eurogamer.net/articles/2020-09-03-everything-announced-in-nintendos-super-mario-bros-35th-anniversary-direct",
         "icon":"block.svg",
         "alt": "This incident is about something getting blocked or restricted",
         "date":"2020-09-18",
-        "name":"SM 3D A-S announcement shows the game will have limited release",
-        "description": "The game includes re-releases of three iconic 3D M games was announced but will only have a limited run, after march 31st 2021 the game is not on the eshop or stores."
+        "name":"Super Mario 3D All-Stars had a limited release",
+        "description": "The game includes re-releases of three iconic 3D Mario games was announced but will only have a limited run, after march 31st 2021 the game is not on the eshop or stores."
     },
     {
         "url": "https://www.eurogamer.net/articles/2020-09-03-the-original-super-mario-bros-is-getting-the-battle-royale-treatment",
         "icon":"block.svg",
         "alt": "This incident is about something getting blocked or restricted",
         "date":"2020-09-18",
-        "name":"SM 35 announcement shows the game will have limited time to play",
-        "description": "The game was similar to Tetris 99 where you play the original MB game against 35 other players, a similar concept to a battle royale. It was free for members of the Online service and after march 31st 2021 the game was shut down."
+        "name":"Super Mario 35 had limited time to play",
+        "description": "The game was similar to Tetris 99 where you play the original Mario Bros game against 35 other players, a similar concept to a battle royale. It was free for members of the Online service and after march 31st 2021 the game was shut down."
     },
     {
         "url": "https://torrentfreak.com/nintendo-wants-permanent-injunction-to-shut-down-switch-piracy-hack-stores-200907/",
         "icon":"block.svg",
         "alt": "This incident is about something getting blocked or restricted",
         "date":"2020-09-07",
-        "name":"The big N wants permantent Injuction to piracy stores",
+        "name":"Nintendo wants permantent Injuction to piracy stores",
         "description": "The company asked the court to issue a default judgment and permanent injunction to shut down several stores that sell Team-Xecuter's Switch hacks and mods."
     },
     {
@@ -165,14 +165,14 @@
         "alt": "This incident was about something getting sued or a legal letter was sent",
         "date":"2020-05-19",
         "name":"Lawsuits are sent to resellers of switch hacking devices",
-        "description": "The big N filed two lawsuits against resellers of devices made to hack the switch console and allow users to play pirated games on all models of the console."
+        "description": "Nintendo filed two lawsuits against resellers of devices made to hack the switch console and allow users to play pirated games on all models of the console."
     },
     {
         "url": "https://torrentfreak.com/nintendo-lawyers-file-copyright-complaints-against-super-mario-64-pc-port-200508/",
         "icon":"law.svg",
         "alt": "This incident was about something getting sued or a legal letter was sent",
         "date":"2020-05-07",
-        "name":"SM 64 PC port",
+        "name":"Super Mario 64 PC port",
         "description": "A fan made pc port of the game and the company filed copyright takedowns for any video on youtube showcasing the game and websites hosting the game."
     },
     {
@@ -180,7 +180,7 @@
         "icon":"block.svg",
         "alt": "This incident is about something getting blocked or restricted",
         "date":"2020-02-1",
-        "name":"AC:NH Only allows 1 island per console",
+        "name":"Animal Crossing: New Horizons Only allows 1 island per console",
         "description":"No matter how many accounts or copies of the game players have, the game only allows one island per console. Previous versions of the franchise worked similarly on past hardware, but the company did not provide an explanation this time."
     },
     {
@@ -189,15 +189,15 @@
         "alt": "This incident was about something getting sued or a legal letter was sent",
         "date":"2019-09-11",
         "name":"RomUniverse is taken to court",
-        "description": "The big N filed a lawsuit against ROM site, RomUniverse, for copyright and trademak infirngement since the site distributed ROMs from games made by the company."
+        "description": "Nintendo filed a lawsuit against ROM site, RomUniverse, for copyright and trademak infirngement since the site distributed ROMs from games made by the company."
     },
     {
         "url": "https://torrentfreak.com/nintendo-takes-down-facebook-tooled-donkey-kong-remake-190930/",
         "icon":"law.svg",
         "alt": "This incident was about something getting sued or a legal letter was sent",
         "date":"2019-09-30",
-        "name":"DK remake receives takedown",
-        "description": "A company created a remake of the game as a technical demo on Github and the big N sent DMCA takedowns of the project and every fork made to it."
+        "name":"Donkey Kong remake receives takedown",
+        "description": "A company created a remake of the game as a technical demo on Github and Nintendo sent DMCA takedowns of the project and every fork made to it."
     },
     {
         "url": "https://www.nintendolife.com/news/2019/08/nintendo_music_copyright_takedowns_intensify_as_another_prominent_youtuber_gets_hit",
@@ -205,31 +205,31 @@
         "alt": "This incident was about something getting sued or a legal letter was sent",
         "date":"2019-08-14",
         "name":"Copyright takedowns are sent to Youtube game music channels",
-        "description": "The big N sent DMCA Takedowns to Youtube channels that posted official music of their games."
+        "description": "Nintendo sent DMCA Takedowns to Youtube channels that posted official music of their games."
     },
     {
         "url": "https://www.youtube.com/watch?v=kJGcDU4esUY",
         "icon":"law.svg",
         "alt": "This incident was about something getting sued or a legal letter was sent",
         "date":"2019-07-14",
-        "name":"M royale (Infringio) Taken down",
-        "description": "A fanmade battle royale version of the original M game was created by a fan and the big N constantly issued takedown notices, even when the creator made different changes to the game."
+        "name":"Mario royale (Infringio) Taken down",
+        "description": "A fanmade battle royale version of the original Mario game was created by a fan and Nintendo constantly issued takedown notices, even when the creator made different changes to the game."
     },
     {
         "url": "https://www.eurogamer.net/articles/2018-11-29-nintendo-scraps-creators-program-making-life-much-easier-for-youtubers",
         "icon":"block.svg",
         "alt": "This incident is about something getting blocked or restricted",
         "date":"2018-11-29",
-        "name":"The big N stops the Creators Program",
-        "description": "The big N shut down the Creators Program that allowed content creators to create videos on Youtube of their videogames in exchange for a cut of the ad revenue."
+        "name":"Nintendo stops the Creators Program",
+        "description": "Nintendo shut down the Creators Program that allowed content creators to create videos on Youtube of their videogames in exchange for a cut of the ad revenue."
     },
     {
         "url": "https://finance.yahoo.com/news/arizona-couple-ordered-pay-nintendo-210700185.html",
         "icon":"balance.svg",
-        "alt": "This incident was about someone having to pay compensation or any monetary problems caused by the big N",
+        "alt": "This incident was about someone having to pay compensation or any monetary problems caused by Nintendo",
         "date":"2018-11-13",
         "name":"Two ROM sites were ordered to pay millions and shut down",
-        "description": "Two ROM sites offered copies of different games and the big N filed a lawsuit and won, which forced the sites to pay millions and shut down the websites."
+        "description": "Two ROM sites offered copies of different games and Nintendo filed a lawsuit and won, which forced the sites to pay millions and shut down the websites."
     },
     {
         "url": "https://www.polygon.com/2018/7/22/17600008/nintendo-roms-lawsuit-cease-desist",
@@ -237,7 +237,7 @@
         "alt": "This incident was about something getting sued or a legal letter was sent",
         "date":"2018-07-22",
         "name":"Two ROM sites were sued",
-        "description": "Two ROM sites offered copies of different games and the big N filed a lawsuit against the operators of the two websites."
+        "description": "Two ROM sites offered copies of different games and Nintendo filed a lawsuit against the operators of the two websites."
     },
     {
         "url": "https://www.gameinformer.com/b/news/archive/2017/09/29/nintendo-updates-youtube-partners-program-to-restrict-live-streaming.aspx",
@@ -252,15 +252,15 @@
         "icon":"law.svg",
         "alt": "This incident was about something getting sued or a legal letter was sent",
         "date":"2017-09-20",
-        "name":"SM 64 Online gets Copyright takedowns and strikes",
-        "description": "The SM 64 online game project made by a fan was removed from Patreon and Youtube after the big N sent copyright claims and takedown notices."
+        "name":"Super Mario 64 Online gets Copyright takedowns and strikes",
+        "description": "The Super Mario 64 online game project made by a fan was removed from Patreon and Youtube after Nintendo sent copyright claims and takedown notices."
     },
     {
         "url": "https://torrentfreak.com/nintendo-shuts-down-donkey-kong-remake-for-roku-170630/",
         "icon":"law.svg",
         "alt": "This incident was about something getting sued or a legal letter was sent",
         "date":"2017-06-30",
-        "name":"DK remake for Roku was shutdown",
+        "name":"Donkey Kong remake for Roku was shutdown",
         "description": "A fan made a remake of the game for Roku as an excercise. But the company filed a DMCA takedown and the game was removed from github."
     },
     {
@@ -268,16 +268,16 @@
         "icon":"law.svg",
         "alt": "This incident was about something getting sued or a legal letter was sent",
         "date":"2016-12-21",
-        "name": "PK Prism is cancelled",
-        "description" :"PK Prism and PK Brown, two rom hacks made as fan games by a single developer, were cancelled and removed, respectively, by the creator after a legal document was sent by the big N requesting the removal of both of the romhacks and further involvement by the developer."
+        "name": "Pokémon Prism is cancelled",
+        "description" :"Pokémon Prism and Pokémon Brown, two rom hacks made as fan games by a single developer, were cancelled and removed, respectively, by the creator after a legal document was sent by Nintendo requesting the removal of both of the romhacks and further involvement by the developer."
     },
     {
         "url": "http://web.archive.org/web/20211108065656/https://oripoke.wordpress.com/2016/10/20/the-explosion-and-fallout-of-pokemon-uranium/",
         "icon":"law.svg",
         "alt": "This incident was about something getting sued or a legal letter was sent",
         "date":"2016-09-21",
-        "name":"Uranium is taken down",
-        "description": "A fanmade game is created and a few weeks later all the download links are removed by it's creators, it was later revealed that the big N sent a legal leter to the creators"
+        "name":"Pokémon Uranium is taken down",
+        "description": "A fanmade game is created and a few weeks later all the download links are removed by it's creators, it was later revealed that Nintendo sent a legal leter to the creators"
     },
     {
         "url": "https://www.wired.co.uk/article/nintendo-removes-500-games",
@@ -285,7 +285,7 @@
         "alt": "This incident was about something getting sued or a legal letter was sent",
         "date":"2016-09-06",
         "name":"Takedown of more than 500 indie games",
-        "description": "526 fanmade inde games based on games by the big N received a DMCA takedown on Gamejolt, a website dedicated to hosting indie games."
+        "description": "526 fanmade inde games based on games by Nintendo received a DMCA takedown on Gamejolt, a website dedicated to hosting indie games."
     },
     {
         "url": "https://kotaku.com/brilliant-fan-remake-of-metroid-ii-arrives-just-in-time-1784929739",
@@ -293,7 +293,7 @@
         "alt": "This incident is about something getting blocked or restricted",
         "date":"2016-08-06",
         "name":"The original release AM2R gets blocked everywhere",
-        "description": "A fanmade remake of M2 got removed with takedowns by the big N and evey website that hosted the ROM received DMCA takedown notices."
+        "description": "A fanmade remake of M2 got removed with takedowns by Nintendo and evey website that hosted the ROM received DMCA takedown notices."
     },
     {
         "url": "https://www.eurogamer.net/articles/2016-04-07-zeldas-browser-based-fan-remake-shut-down-by-nintendo",
@@ -301,7 +301,7 @@
         "alt": "This incident was about something getting sued or a legal letter was sent",
         "date":"2016-04-07",
         "name":"Fanmade Zelda 30 Tribute shuts down",
-        "description": "A group of fans made a voxel version of the first Zelda game, the big N issued a copyright strike and told them to remove the game."
+        "description": "A group of fans made a voxel version of the first Zelda game, Nintendo issued a copyright strike and told them to remove the game."
     },
     {
         "url": "https://kotaku.com/what-happened-after-nintendo-cracked-down-on-a-zelda-fa-1794176131",
@@ -309,22 +309,22 @@
         "alt": "This incident was about something getting sued or a legal letter was sent",
         "date":"2015-11-10",
         "name":"\"Zelda Maker\" is taken down",
-        "description": "A fanmade \"Zelda Maker\" game was created and the big N copyright claimed the creator videos on Youtube and sent a DMCA notice to MediaFire where the game was hosted. The creator revamped the project with new assets and a new name."
+        "description": "A fanmade \"Zelda Maker\" game was created and Nintendo copyright claimed the creator videos on Youtube and sent a DMCA notice to MediaFire where the game was hosted. The creator revamped the project with new assets and a new name."
     },
     {
         "url": "http://web.archive.org/web/20150403200612/https://roystanross.wordpress.com/super-mario-64-hd/",
         "icon":"law.svg",
         "alt": "This incident was about something getting sued or a legal letter was sent",
         "date":"2015-04-03",
-        "name":"Fanmade HD remake of M64",
-        "description" :"A Unity indie developer made a fan recreation of the first level of M64 and a few days later received a copyright infringement notice for the webplayer and the standalone builds of the game."
+        "name":"Fanmade HD remake of Mario 64",
+        "description" :"A Unity indie developer made a fan recreation of the first level of Mario 64 and a few days later received a copyright infringement notice for the webplayer and the standalone builds of the game."
     },
     {
         "url": "https://www.destructoid.com/nintendos-cracking-down-on-speedrunning-and-rom-hacking-videos/",
         "icon":"block.svg",
         "alt": "This incident is about something getting blocked or restricted",
         "date":"2015-09-10",
-        "name":"Videos about speedrunns and ROM hacks are removed",
+        "name":"Videos about speedruns and ROM hacks are removed",
         "description": "The company removed videos on Youtube about ROM hacks of their games, specifically speedruns and videos showcasing ROM hacks."
     },
     {
@@ -332,16 +332,16 @@
         "icon":"law.svg",
         "alt": "This incident was about something getting sued or a legal letter was sent",
         "date":"2015-07-12",
-        "name":"a GBA browser emulator is taken down",
-        "description":"A GBA emulator was uploaded and hosted on github by a developer. The emulator inluded ROM copies of games and the big N sent a takedown notice, the website and the code behind it was removed."
+        "name":"A GBA browser emulator is taken down",
+        "description":"A Game Boy Advance emulator was uploaded and hosted on github by a developer. The emulator inluded ROM copies of games and Nintendo sent a takedown notice, the website and the code behind it was removed."
     },
     {
         "url": "https://arstechnica.com/gaming/2015/01/nintendo-to-share-up-to-70-percent-of-ad-revenue-with-game-youtubers",
         "icon":"balance.svg",
-        "alt": "This incident was about someone having to pay compensation or any monetary problems caused by the big N",
+        "alt": "This incident was about someone having to pay compensation or any monetary problems caused by Nintendo",
         "date":"2015-01-29",
-        "name":"The big N shared cut of content creators revenue on youtube",
-        "description": "The big N created the \"Creators Program\", to allow Youtube users to create content from their games but only the ones white listed from the company, and giving the big N a cut of the ad revenue of each video."
+        "name":"Nintendo shared cut of content creators revenue on youtube",
+        "description": "Nintendo created the \"Nintendo Creators Program\", to allow Youtube users to create content from their games but only the ones white listed from the company, and giving Nintendo a cut of the ad revenue of each video."
     },
     {
         "url": "https://torrentfreak.com/nintendo-nukes-hugely-popular-ios-game-boy-emulator-140514/",
@@ -349,14 +349,14 @@
         "alt": "This incident was about something getting sued or a legal letter was sent",
         "date":"2014-05-14",
         "name":"A GBA emulator for iOS is taken down",
-        "description":"A high-school student made a GBA emuator for iOS that allowed to be installed without jailbreak, the big N sent a Takedown requesting to remove the code from Github."
+        "description":"A high-school student made a GBA emuator for iOS that allowed to be installed without jailbreak, Nintendo sent a Takedown requesting to remove the code from Github."
     },
     {
         "url": "https://www.bbc.com/news/technology-27321200",
         "icon":"block.svg",
         "alt": "This incident is about something getting blocked or restricted",
         "date":"2014-05-08",
-        "name":"The big N says 'No' to gay game charaters",
+        "name":"Nintendo says 'No' to gay game charaters",
         "description": "After the company released Tomodachi Life, a life-simulation game, a fan launched a social media campaign asking to allow same-sex relationships in the game. The company replied that \"never intended to make any form of social commentary with the game\"."
     },
     {
@@ -364,8 +364,8 @@
         "icon":"law.svg",
         "alt": "This incident was about something getting sued or a legal letter was sent",
         "date":"2013-10-21",
-        "name":"Full Screen MB taken down",
-        "description": "A fanmade version of the NES game was made to run on browsers with widescreen support, the big N took legal action and forced the creator to remove the working game."
+        "name":"Full Screen Mario Bros taken down",
+        "description": "A fanmade version of the NES game was made to run on browsers with widescreen support, Nintendo took legal action and forced the creator to remove the working game."
     },
     {
         "url": "https://kotaku.com/nintendo-wont-let-top-fighting-game-tournament-stream-s-724293474",
@@ -373,23 +373,23 @@
         "alt": "This incident is about something getting blocked or restricted",
         "date":"2013-07-09",
         "name":"Evo 2013",
-        "description": "Fans of SSBM raised thousands of dollars in charity to participate in EVO and the big N pushed to cancel the stream and then the event. In the end the big N decided to revert the decison"
+        "description": "Fans of SSBM raised thousands of dollars in charity to participate in EVO and Nintendo pushed to cancel the stream and then the event. In the end Nintendo decided to revert the decison"
     },
     {
         "url": "https://www.polygon.com/2013/5/16/4336114/nintendo-claims-ad-revenue-on-user-generated-youtube-videos",
         "icon":"balance.svg",
-        "alt": "This incident was about someone having to pay compensation or any monetary problems caused by the big N",
+        "alt": "This incident was about someone having to pay compensation or any monetary problems caused by Nintendo",
         "date":"2013-05-15",
-        "name":"The big N claimed ad revenue on videos from users on youtube",
-        "description": "The big N used the Youtube content ID to claim revenue from user generated videos. The company registered it's copyright content on the system in order to include or claim money from video ads."
+        "name":"Nintendo claimed ad revenue on videos from users on youtube",
+        "description": "Nintendo used the Youtube content ID to claim revenue from user generated videos. The company registered it's copyright content on the system in order to include or claim money from video ads."
     },
     {
         "url": "http://web.archive.org/web/20181116062241/http://www.majorleaguegaming.com/news/league-speak-with-sundance-super-smash-bros-brawl-stream",
         "icon":"block.svg",
         "alt": "This incident is about something getting blocked or restricted",
         "date":"2010-04-15",
-        "name":"MLG Brawl 2010",
-        "description": "The MLG Orlando 2010 had a SSBB tournament and wasn't allowed to stream the tournament online because the big N didn't give MLG the necessary live streaming rights."
+        "name":"MLG SSBB 2010",
+        "description": "The MLG Orlando 2010 had a SSBB tournament and wasn't allowed to stream the tournament online because Nintendo didn't give MLG the necessary live streaming rights."
     },
     {
         "url": "https://www.engadget.com/2010-04-02-nintendo-shuts-down-fan-made-pokemon-mmo.html",
@@ -397,7 +397,7 @@
         "alt": "This incident was about something getting sued or a legal letter was sent",
         "date":"2010-04-02",
         "name":"A fan made Pokémon MMO was shut down",
-        "description": "A group of fans created an MMO version of Pokémon and the big N sent a cease and desist letter requesting them to take down the website and surrender the domain name too."
+        "description": "A group of fans created an MMO version of Pokémon and Nintendo sent a cease and desist letter requesting them to take down the website and surrender the domain name too."
     },
     {
         "url": "http://web.archive.org/web/20060820035536/http://www.consoleclassix.com/letter_from_noa.php",
@@ -405,6 +405,6 @@
         "alt": "This incident was about something getting sued or a legal letter was sent",
         "date":"2001-06-01",
         "name":"Console Clasix received a cease & desist letter",
-        "description": "Console Clasix, a rental service that operates with thousands of physical ROMs, was sent a cease & desist letter to stop the service. They replied stating why it wasn't illegal and never heard from the big N again."
+        "description": "Console Clasix, a rental service that operates with thousands of physical ROMs, was sent a cease & desist letter to stop the service. They replied stating why it wasn't illegal and never heard from Nintendo again."
     }
 ]

--- a/index.html
+++ b/index.html
@@ -6,18 +6,18 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="keywords" content="videogames, lawsuit, collection, compendium">
     <meta name="description" content="A collection of lawsuits, legal actions and interesting events made by the big N">
-    <title>Sued by "the big N"</title>
+    <title>Sued by Nintendo</title>
     <link rel="shortcut icon" href="./images/big-N.png" type="image/png"/>
     <link rel="stylesheet" href="./fonts/Mark/stylesheet.css" onload="this.media='all'">
     <link rel="stylesheet" href="./styles/main.css" onload="this.media='all'">
 
-    <meta property="og:title" content="Sued by &ldquo;the big N&rdquo;" />
+    <meta property="og:title" content="Sued by Nintendo" />
     <meta property="og:type" content="website" />
     <meta property="og:image" content="https://cawolfkreo.github.io/Cease-and-Desist-History-Big-N/images/banner.jpg" />
     <meta property="og:url" content="https://cawolfkreo.github.io/Cease-and-Desist-History-Big-N"/>
     <meta property="og:description" content="A list of legal and interesting actions taken by the big N." />
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Sued by &ldquo;the big N&rdquo;">
+    <meta name="twitter:title" content="Sued by Nintendo">
     <meta name="twitter:description" content="A list of legal and interesting actions taken by the big N.">
     <meta name="twitter:image" content="https://cawolfkreo.github.io/Cease-and-Desist-History-Big-N/images/banner.jpg" />
 </head>


### PR DESCRIPTION
# Description
I "discussed this with the legal team" and apparently is ok to mention Nintendo and it's games. I **cannot put the word "Nintendo" on the banner"** but that's ok as the parody banner the website has is more than perfect (plus I asked for permission from the melee stats discord and the creator of the thumbnail of their video).

## What changed
* Updated the `data.json` file and changed every single instance of "the big N" to "Nintendo", same thing for characters and videogames.
* Updated the HTML so that the metadata and title includes "Nintendo".