### PR TITLE
Nintendo removes steam deck videos :rage4:

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -1,5 +1,12 @@
 [
     {
+        "url": "https://www.eurogamer.net/articles/2022-03-03-steam-deck-nintendo-emulation-videos-are-disappearing-from-youtube",
+        "icon":"block.svg",
+        "date":"2022-3-3",
+        "name":"Steam Deck videos removed by Nintendo",
+        "description": "Videos on Youtube showing the Steam Deck (Valve's first handheld console) emulating Switch games, were apparently taken down by Nintendo."
+    },
+    {
         "url": "https://web.archive.org/web/20220227153917/https://twitter.com/EVO/status/1497662793897721860",
         "icon":"block.svg",
         "date":"2022-2-26",


### PR DESCRIPTION
Apparently Nintendo removed some videos on Youtube of people emulating Switch, Wii and gamecube games on the Switch using the Yuzu and Dolphin emulators. I added an article from Eurogamer but I also believe [this is another good article](https://www.nintendolife.com/news/2022/03/steam-deck-nintendo-emulation-videos-are-being-pulled-from-youtube) to keep in mind from Nintendo life :godmode:.