### PR TITLE
Added Prime music cover scandal :rage1:

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -1,4 +1,12 @@
-[   {
+[
+    {
+        "url": "https://www.nintendolife.com/news/2022/06/youtuber-ends-metroid-prime-music-covers-after-nintendos-lawyers-call",
+        "icon":"block.svg",
+        "date": "2022-06-15",
+        "name": "Metroid Prime covers were removed from Youtube",
+        "description": "Covers and remixes of Metroid Prime music were removed after the owner of these videos was contacted by a lawyer from Nintendo asking them to remove them."
+    },
+    {
         "url": "https://kotaku.com/nintendo-music-youtube-deoxysprime-legal-lawyers-copyri-1849005989",
         "icon": "block.svg",
         "date": "2022-06-03",


### PR DESCRIPTION
# Description

This is a simple event where a Nintendo lawyer contacted a youtuber and prompted them to remove videos of covers and remixes of music from Metroid Prime from their channel. The videos [were removed by the channel owner, as confirmed by their video.](https://www.youtube.com/watch?v=YMPlvdbbMhg)