### PR TITLE
Improved the alt text for the icons :godmode: 

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -21,15 +21,15 @@
 */
 const ITEMS_KEY = {
     "balance.svg": {
-        alt: "This incident was about someone having to pay compensation or any monetary problems caused by Nintendo",
+        alt: "A balance with no loads or lifts on it. It's in equilibrium.",
         message: "Nintendo has collected !num coins."
     },
     "block.svg": {
-        alt: "This incident is about something getting blocked or restricted",
+        alt: "A circle with a stroke in the middle. Represents blocking or prevention.",
         message: "Nintendo re-locked content !num times."
     },
     "law.svg": {
-        alt: "This incident was about something getting sued or a legal letter was sent",
+        alt: "A Gavel floating in a 45 degree angle.",
         message: "Nintendo invited lawyers to smash !num times."
     },
 }


### PR DESCRIPTION
# Description
I noticed the alt text was really not helpful at all. I did heard complaints in the past about this and I turned a blind eye to this issue. It's better to fix this sooner than later so I updated the text for those icons. I still think the text could be improved, but in the mean time this should be more than enough.