### PR TITLE
Created new render workflow and fixed readibility :godmode: 

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -22,16 +22,26 @@
 const ITEMS_KEY = {
     "balance.svg": {
         alt: "A balance with no loads or lifts on it. It's in equilibrium.",
-        message: "Nintendo has collected !num coins."
+        message: messageFormat("Nintendo has collected !num coins.")
     },
     "block.svg": {
         alt: "A circle with a stroke in the middle. Represents blocking or prevention.",
-        message: "Nintendo re-locked content !num times."
+        message: messageFormat("Nintendo re-locked content !num times.")
     },
     "law.svg": {
         alt: "A Gavel floating in a 45 degree angle.",
-        message: "Nintendo invited lawyers to smash !num times."
+        message: messageFormat("Nintendo invited lawyers to smash !num times.")
     },
+}
+
+/**
+ * Formats the message into a prefix
+ * and a suffix in an array.
+ * @param {String} message the message to format
+ * @returns an array of two items, a prefix and a sufix
+ */
+function messageFormat(message) {
+    return message.split("!num");
 }
 
 /**
@@ -141,7 +151,7 @@ function attachToInput(data) {
 * Calculates the total number of
 * incidents for each type of
 * incidents on the array.
-* @param {Array<Incident>} data 
+* @param {Array<Incident>} data The list of incidents to count
 * @returns An object with each type of incident as it's properties and the total number of each of them in data.
 */
 function countIncidentTypes(data) {
@@ -156,48 +166,41 @@ function countIncidentTypes(data) {
 }
 
 /**
-* Creates a paragraph with based on the specified message and the count of incidents passed
-* @param {Number} count The count to be displayed on the paragraph for this incident
-* @param {String} templateMsg The template message to use for the paragraph text
-* @param {Object} [atributes] The attribues object to use for the object created.
-* @returns An <p> HTML element with the message on it.
-*/
-function incidentCounterMessage(count, templateMsg, atributes={}) {
-    const indivdualCounter = createElement("p", atributes);
-    const message = templateMsg.replace("!num", `<span class="num">${count}</span>`);
-    indivdualCounter.innerHTML = message;
-    return indivdualCounter;
+ * Renders the counter message for the
+ * incident count.
+ * @param {String} prefix The text node to display before the counter
+ * @param {Number} count The count to display
+ * @param {String} sufix The text node to display after the counter
+ * @param {Object} [atributes] The attribues object to use for the object created.
+ * @returns A <p> HTML element with the message counter on it.
+ */
+ function incidentCounterMessage(prefix, count, sufix, attribues={}) {
+    return createElement("p", attribues,[
+        document.createTextNode(prefix),
+        createElement("span", { className: "num", innerText: count}),
+        document.createTextNode(sufix)
+    ]);
 }
 
+/**
+ * Creates a row component that holds
+ * the different counters for the list
+ * of incidents so far
+ * @param {Array<incident>} data The data that will be used to update the counters
+ * @returns The row of counters to be displayed
+ */
 function specificCountersRow(data) {
     const incidentTotals = countIncidentTypes(data);
     const incidentTypes = Object.entries(ITEMS_KEY);
     
     return createElement("div", {className: "countRow"}, 
-        incidentTypes.map(([incidentType, typeItem]) => (
+        incidentTypes.map(([incidentType, {alt, message:[prefix, sufix]}]) => (
             createElement("div", {className:"countDiv"}, [
-                createElement("img", {src: `./images/${incidentType}`, alt: typeItem.alt}),
-                incidentCounterMessage(incidentTotals[incidentType], typeItem.message)
+                createElement("img", {src: `./images/${incidentType}`, alt}),
+                incidentCounterMessage(prefix, incidentTotals[incidentType], sufix)
             ])
         ))
     );
-}
-
-/**
- * Renders the counter message for the
- * incident count.
- * @param {Text} prefix The text node to display before the counter
- * @param {Number} count The count to display
- * @param {Text} suffix The text node to display after the counter
- * @param {Object} [atributes] The attribues object to use for the object created.
- * @returns A <p> HTML element with the message counter on it.
- */
-function test(prefix, count, suffix, attribues={}) {
-    return createElement("p", attribues,[
-        document.createTextNode(prefix),
-        createElement("span", { className: "num", innerText: count}),
-        document.createTextNode(suffix)
-    ]);
 }
 
 /**
@@ -208,7 +211,7 @@ function test(prefix, count, suffix, attribues={}) {
  * @returns The global counter displaying the total number of incidents so far 
  */
 function globalCounter(count) {
-    return test("Nintendo played this game ", count, " times.", {className: "globalCount"});
+    return incidentCounterMessage("Nintendo played this game ", count, " times.", {className: "globalCount"});
 }
 
 /**

--- a/styles/main.css
+++ b/styles/main.css
@@ -102,6 +102,10 @@ footer {
     font-size: 1.5em;
 }
 
+.globalCount > .num {
+    font-size: 3.24em;
+}
+
 .counters > hr {
     margin: 4vw 2vw;
     border: 3px solid var(--foreground-color);


### PR DESCRIPTION
# Description
The generation of the individual counters was messy and looked quite complicated. I decided to have a `render` function that appends the necessary childs to the skelleton `HTMLElement` that will hold the created elements and used that as means to refactor everything and to separate the whole function into smaller ones. This should make thing easier to maintain and make things more clear when working with the JS of the website. 

Additionally, a bug existed where the first counter had two `span` elements like so;
```HTML
<span class="num"><span class="num">!num</span></span>
```
This happened because of how I was interpolating the string in order to include the span inside of each message. I didn't want to use the `innerHtml` attribute nor the double span. For a while this made the number of the main counter bigger thanks to applying the `font-size: 1.8em` rule twice, but a the end of the day it was a "happy accident" and it's not the right way to do this. After my changes on the PR there is only one `span` element and I changed the `css` a bit to target that specific span and make it bigger.  