### PR TITLE
Shadows for items! :tada: 

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -17,6 +17,7 @@
     --foreground-color: #fffdfc;
     --secondary-color: #e2e0d8;
     --foter-color: #A30303;
+    --shadow-color: hsla(0, 0%, 0%, 0.09);
 
     /*transitions*/
     --transition-forms: all 0.25s ease-out;
@@ -135,6 +136,15 @@ footer {
 .dataCell {
     font-family: var(--font-2);
     font-size: 1.17em;
+    padding: 20px;
+    transition: all 0.25s ease-in-out;
+}
+
+.dataCell:hover {
+    box-shadow: var(--shadow-color) 0px 2px 4px,
+                var(--shadow-color) 0px 4px 8px,
+                var(--shadow-color) 0px 12px 24px;
+    transform: translateY(-2%);
 }
 
 .dataCell > a {


### PR DESCRIPTION
# Description
I felt like it wasn't clear that you could click on the grid items and have them take you to the respective article or source. Because of this, I added some shadow to hopefully make it more clear to other people that those items are clickable. So far this change only affects navigating via desktop and not mobile.