### PR TITLE
Added noscript tag and OctoBoy story 👍 

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -1,5 +1,12 @@
 [
     {
+        "url": "https://web.archive.org/web/20221101200442/https://twitter.com/OctoboyYT/status/1587346400366546945",
+        "icon": "block.svg",
+        "date": "2022-11-01",
+        "name": "Youtube channel videos removed for using a mod",
+        "description": "The Youtube channel, OctoBoy, was making splatoon 3 videos using a mod that allowed for better camera angles similar to the trailer videos the developers use. These videos were removed by Nintendo via a copyright claim."
+    },
+    {
         "url": "https://www.nintendolife.com/news/2022/06/youtuber-ends-metroid-prime-music-covers-after-nintendos-lawyers-call",
         "icon":"block.svg",
         "date": "2022-06-14",

--- a/index.html
+++ b/index.html
@@ -46,6 +46,9 @@
             <div class="grid">
                 <p>Wait a moment while the information loads</p>
                 <!--#freeSplatoon-->
+                <noscript>
+                    <p>You need to turn on Javascript to see the list</p>
+                </noscript>
             </div>
         </article>
     </main>


### PR DESCRIPTION
# Description
Apparently I forgot to merge the `noscript` tag for the main content, my mistake. On the other hand, I was told that a youtube channel, OctoBoy, got their videos removed because of Nintendo issuing a copyright strike on videos where they used a mod to have a camera control similar to the Splatoon 3 trailers. I don't think this is fair in the slightest and not seeing any news articles about it or anything outside of a few people complaining about it is quite annoying. This is my grain of sand to help voice this situation.