### PR TITLE
Replace Blockbuster suit URL with archived version

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -567,7 +567,7 @@
         "description": "The Game Genie was a tool made to modify the behaviour of NES games. Nintendo decided to sue the makers of this tool alleging that modifying the game created a derivative work and this violated their Copyrights."
     },
     {
-        "url": "https://www.nintendotimes.com/1989/08/19/nintendo-sues-blockbuster-video-for-copying-instruction-books/",
+        "url": "https://web.archive.org/web/20220720221531/https://www.nintendotimes.com/1989/08/19/nintendo-sues-blockbuster-video-for-copying-instruction-books/",
         "icon":"law.svg",
         "date":"1989-08-19",
         "name":"Nintendo sued Blockbuster for copying instruction books",


### PR DESCRIPTION
original link leads to another website, without the OG article