### PR TITLE
Nintendo Cease and Desist Classic - Retro Emulation Cases

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -567,6 +567,13 @@
         "description": "Console Clasix, a rental service that operates with thousands of physical ROMs, was sent a cease & desist letter to stop the service. They replied stating why it wasn't illegal and never heard from Nintendo again."
     },
     {
+        "url": "https://www.theregister.com/1999/02/03/n64_emulator_vanishes_after_lawsuit/",
+        "icon": "law.svg",
+        "date": "1999-01-28",
+        "name": "UltraHLE Cancelled",
+        "description": "UltraHLE, an early Nintendo 64 emulator, was pulled from its website by its developers out of fear of legal action from Nintendo. Nintendo had previously expressed interest in legal action against UltraHLE."
+    },
+    {
         "url": "https://scholar.google.com/scholar_case?case=14167398686354689030&hl=en&as_sdt=2&as_vis=1&oi=scholarr",
         "icon":"law.svg",
         "date":"1991-07-12",

--- a/data/data.json
+++ b/data/data.json
@@ -553,6 +553,13 @@
         "description":"A fanmade movie based on the story of OoT was uploaded to the internet and then Nintendo contacted the group behind it and requested to remove, at the end of 2009 the movie was removed."
     },
     {
+        "url": "https://web.archive.org/web/20060104215110/http://www.crimsonfire.com:80/community/showthread.php?s=2300fd6df9f7bc3b6997ce564be42b7d&threadid=2410",
+        "icon": "law.svg",
+        "date": "2004-03-12",
+        "name": "Firestorm GBA Emulator",
+        "description": "The development of Firestorm, an upcoming commercial GBA emulator in 2004, was chilled when Nintendo filed a patent on technologies commonly used by emulators at the time."
+    },
+    {
         "url": "http://web.archive.org/web/20060820035536/http://www.consoleclassix.com/letter_from_noa.php",
         "icon":"law.svg",
         "date":"2001-06-01",


### PR DESCRIPTION
I've added the incidents with the Firestorm GBA emulator and the UltraHLE N64 emulator. UltraHLE was a fairly big incident from what I've read about it and Firestorm not so much, but still noteworthy. Both these incidents were more pressure than direct legal action, but that's par for the course for Nintendo's legal tactics and directly resulted in the projects being killed.